### PR TITLE
Fix IDGTool desync

### DIFF
--- a/InDappledGroves/Items/IDGTool.cs
+++ b/InDappledGroves/Items/IDGTool.cs
@@ -174,7 +174,7 @@ namespace InDappledGroves.Items.Tools
                     float curMiningProgress = (secondsUsed + (curDmgFromMiningSpeed)) * (toolModeMod* InDappledGrovesConfig.Current.baseGroundRecipeMiningSpdMult);
                     float curResistance = resistance * InDappledGrovesConfig.Current.baseGroundRecipeResistaceMult;
                     System.Diagnostics.Debug.WriteLine("Tool: " + toolMiningSpeed + " cuResist:" + curResistance + " " + curMiningProgress + " ");
-                    if (curMiningProgress >= curResistance)
+                    if (api.World is Vintagestory.API.Server.IServerWorldAccessor && curMiningProgress >= curResistance)
                     {
                         
                         SpawnOutput(recipe, recipePos);


### PR DESCRIPTION
Copying a pattern used in vanilla things like clayforming to prevent a desync: the block is only removed on the server, which then marks it as dirty and sends an update to clients. This prevents clients from only having the block removed clientside and cancelling the interaction before it occurs on the server.