### PR TITLE
Fix #16 and #17

### DIFF
--- a/InDappledGroves/Items/IDGBark.cs
+++ b/InDappledGroves/Items/IDGBark.cs
@@ -22,13 +22,23 @@ namespace InDappledGroves.Items
         {
             BlockPos pos = blockSel?.Position;
 
-            if (pos != null && api.World.BlockAccessor.GetBlockEntity(pos) is BlockEntityGroundStorage bebgs && MatchSlots(bebgs?.Inventory, slot))
+            if (pos != null && api.World.BlockAccessor.GetBlockEntity(pos) is BlockEntityGroundStorage bebgs)
             {
-                //Deteremine if the block is being placed in water.  This is a temporary patch solution until BehaviorSubmergible gets fully processed.
-                string bundlestate = api.World.BlockAccessor.GetBlock(blockSel.Position, BlockLayersAccess.Fluid).FirstCodePart() == "water" ? "-soaking" : "-dry";
-                //Set the resultant block into the world.
-                api.World.BlockAccessor.SetBlock(api.World.BlockAccessor.GetBlock(new AssetLocation("indappledgroves:barkbundle-" + slot.Itemstack.Collectible.Variant["bark"] + bundlestate)).BlockId, blockSel.Position);
-                handling = EnumHandHandling.Handled;
+                if (MatchSlots(bebgs.Inventory, slot))
+                {
+                    // Only modify the world serverside to avoid desyncs.
+                    if (api.World is Vintagestory.API.Server.IServerWorldAccessor)
+                    {
+                        //Deteremine if the block is being placed in water.  This is a temporary patch solution until BehaviorSubmergible gets fully processed.
+                        string bundlestate = api.World.BlockAccessor.GetBlock(blockSel.Position, BlockLayersAccess.Fluid).FirstCodePart() == "water" ? "-soaking" : "-dry";
+                        //Set the resultant block into the world.
+                        api.World.BlockAccessor.SetBlock(api.World.BlockAccessor.GetBlock(new AssetLocation("indappledgroves:barkbundle-" + slot.Itemstack.Collectible.Variant["bark"] + bundlestate)).BlockId, blockSel.Position);
+                    }
+                    //Consume the last piece of bark on both client and server.
+                    slot.TakeOut(1);
+                    slot.MarkDirty();
+                    handling = EnumHandHandling.Handled;
+                }
             } else
             {
                 base.OnHeldInteractStart(slot, byEntity, blockSel, entitySel, firstEvent, ref handling);
@@ -42,21 +52,27 @@ namespace InDappledGroves.Items
         /// <returns>Returns true if all four groundstorage slots contain the same bark as the player is holding.</returns>
         private bool MatchSlots(InventoryBase inv, ItemSlot slot)
         {
-
-            if (!inv[0].Empty)
+            if (slot.Empty || slot.Itemstack.Collectible.Variant["state"] != "dry")
             {
-                for (int i = 0; i < inv.Count; i++)
+                return false;
+            }
+            if (inv[0].Empty || inv[0].Itemstack.Collectible.Variant["state"] != "dry")
+            {
+                return false;
+            }
+            string firstbarktype = inv[0].Itemstack.Collectible.Variant["bark"];
+            if (slot.Itemstack.Collectible.Variant["bark"] != firstbarktype)
+            {
+                return false;
+            }
+            for (int i = 1; i < inv.Count; i++)
+            {
+                if (inv[i].Empty || inv[i].Itemstack.Collectible.Variant["bark"] != firstbarktype || inv[i].Itemstack.Collectible.Variant["state"] != "dry")
                 {
-                    if (inv[0].Empty && !slot.Empty) return false;
-                    string barktype = inv[0].Itemstack.Collectible.Variant["bark"];
-                    for (int j = 0; j < inv.Count; j++)
-                    {
-                        if (inv[j].Empty || !(inv[j].Itemstack.Collectible.Variant["bark"] == barktype) || !(inv[j].Itemstack.Collectible.Variant["state"] == "dry")) return false;
-                    }
-                    return true;
+                    return false;
                 }
             }
-            return false;
+            return true;
         }
     }
 }


### PR DESCRIPTION
Fix #16 and #17 with the following modifications:
- The bundle block is only set on the server to prevent the potential for desyncs.
- The conditional in OnHeldInteractStart is rewritten so that `base.OnHeldInteractStart` isn't called even if the bark doesn't match—I think this was to prevent picking up the bark when you shouldn't.
- Actually consumes the last piece of bark to fix #16.
- Rewrites `MatchSlots` to make sure the held slot matches the bark. Also makes it O(N) instead of O(N^2) which doesn't really matter since there's only four slots, but still. (The reason it didn't work before is because it would always return true if the first one matched, because of an unconditional `return true;` inside the for loop. That's why there was an unreachable code warning.)