### PR TITLE
Fix pine stumps generating instead of tree hollows

### DIFF
--- a/InDappledGroves/Blocks/BlockTreeHollowGrown.cs
+++ b/InDappledGroves/Blocks/BlockTreeHollowGrown.cs
@@ -103,5 +103,37 @@
                 }
                 return null;
             }
+
+        /// <summary>
+        /// Allows replacing logs with grown hollows.
+        /// </summary>
+        /// <param name="blockAccessor"></param>
+        /// <param name="pos"></param>
+        /// <param name="onBlockFace"></param>
+        /// <param name="worldgenRandom"></param>
+        /// <returns></returns>
+        public override bool TryPlaceBlockForWorldGen(IBlockAccessor blockAccessor, BlockPos pos, BlockFacing onBlockFace, LCGRandom worldgenRandom)
+        {
+            Block block = blockAccessor.GetBlock(pos);
+
+            if (block.IsReplacableBy(this) || block.FirstCodePart() == "log")
+            {
+                if (block.EntityClass != null)
+                {
+                    blockAccessor.RemoveBlockEntity(pos);
+                }
+
+                blockAccessor.SetBlock(BlockId, pos);
+
+                if (EntityClass != null)
+                {
+                    blockAccessor.SpawnBlockEntity(EntityClass, pos);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
         }
     }

--- a/InDappledGroves/WorldGen/TreeHollows.cs
+++ b/InDappledGroves/WorldGen/TreeHollows.cs
@@ -136,10 +136,9 @@ namespace InDappledGroves.WorldGen
                 //arbitrarily limit z axis scan for performance reasons (/4)
                 for (var z = 0; z < this.chunkSize; z++)
                 {
-                    int terrainHeight = this.worldBlockAccessor.GetTerrainMapheightAt(blockPos);
                     blockPos.X = (pos.X * this.chunkSize) + x;
-                    blockPos.Y = this.worldBlockAccessor.GetTerrainMapheightAt(blockPos) + 1;
                     blockPos.Z = (pos.Z * this.chunkSize) + z;
+                    blockPos.Y = this.worldBlockAccessor.GetTerrainMapheightAt(blockPos) + 1;
                     Block curBlock = this.chunkGenBlockAccessor.GetBlock(blockPos, BlockLayersAccess.Default);
 
                     if (!IsStumpLog(curBlock) || this.worldBlockAccessor.GetBlock(blockPos.DownCopy()).Fertility > 0) continue;
@@ -151,12 +150,8 @@ namespace InDappledGroves.WorldGen
                             hollowsPlacedCount++;
                             continue;
                         }
-                        PlaceTreeStump(this.chunkGenBlockAccessor, blockPos);
                     }
-                    else
-                    {
-                        PlaceTreeStump(this.chunkGenBlockAccessor, blockPos);
-                    }
+                    PlaceTreeStump(this.chunkGenBlockAccessor, blockPos);
 
 
 
@@ -253,7 +248,7 @@ namespace InDappledGroves.WorldGen
             var upCandidateBlock = blockAccessor.GetBlock(pos.UpCopy(upCount), BlockLayersAccess.Default);
 
             if (upCandidateBlock.FirstCodePart() == "log")
-            { pos = pos.Up(upCount); }
+            { pos = pos.UpCopy(upCount); }
 
             var treeBlock = blockAccessor.GetBlock(pos, BlockLayersAccess.Default);
             //Debug.WriteLine("Will replace:" + treeBlock.Code.Path);
@@ -280,7 +275,6 @@ namespace InDappledGroves.WorldGen
             //Debug.WriteLine("With: " + withPath);
             var withBlockID = this.sapi.WorldManager.GetBlockId(new AssetLocation(withPath));
             var withBlock = blockAccessor.GetBlock(withBlockID);
-            blockAccessor.SetBlock(0, pos);
             if (withBlock.TryPlaceBlockForWorldGen(blockAccessor, pos, BlockFacing.UP, null))
             {
                 var block = blockAccessor.GetBlock(pos, BlockLayersAccess.Default) as BlockTreeHollowGrown;

--- a/InDappledGroves/indappledgroves-doc.xml
+++ b/InDappledGroves/indappledgroves-doc.xml
@@ -21,6 +21,16 @@
             <param name="side">The side.</param>
             <returns></returns>
         </member>
+        <member name="M:InDappledGroves.Blocks.BlockTreeHollowGrown.TryPlaceBlockForWorldGen(Vintagestory.API.Common.IBlockAccessor,Vintagestory.API.MathTools.BlockPos,Vintagestory.API.MathTools.BlockFacing,Vintagestory.API.MathTools.LCGRandom)">
+            <summary>
+            Allows replacing logs with grown hollows.
+            </summary>
+            <param name="blockAccessor"></param>
+            <param name="pos"></param>
+            <param name="onBlockFace"></param>
+            <param name="worldgenRandom"></param>
+            <returns></returns>
+        </member>
         <member name="M:InDappledGroves.Blocks.IDGSawHorse.IsNotDiagonal(Vintagestory.API.MathTools.BlockPos,Vintagestory.API.MathTools.BlockPos)">
             <summary>Determines whether [is not diagonal] [the specified position].</summary>
             <param name="pos">The position of the placed sawhorse block</param>


### PR DESCRIPTION
Fixes #23.
- By overriding `TryPlaceBlockForWorldGen()`  for grown tree hollows, we can avoid having to run `SetBlock(0, pos)` beforehand, which avoids the issue of losing the wood type if hollow placement fails.
- By reordering the x, y, and z selection in `runTreeGen()`, we avoid a lag-by-one error when getting the terrain map height. This fixes stumps generating level with the prior adjacent block on the Z axis rather than at the bottom of the tree.
- Reorganizes the first two `PlaceTreeStump()` calls in `runTreeGen()` to be just one unconditional call, skipped by the `continue` if we succeed in placing a hollow.
- By using `UpCopy()` instead of `Up()` in `PlaceTreeHollow()`, we avoid the issue of stumps mysteriously generating in the middle of trees with no hollows. Before, it was mutating the `BlockPos` object passed in, which would then be used in `PlaceTreeStump()`.